### PR TITLE
New Feature: --apt-source option for sources.list files

### DIFF
--- a/repoaudit/repoaudit/__init__.py
+++ b/repoaudit/repoaudit/__init__.py
@@ -34,16 +34,6 @@ pubkey_option = click.option(
     )
 )
 
-apt_sources_option = click.option(
-    "--apt-source",
-    "-a",
-    required=False,
-    help=(
-        "Supply apt sources.list file. When provided, all entries"
-        "will be parsed for repo urls and their respective dists."
-    )
-)
-
 def _validate_apt_url(recursive: bool, url: str, dists: str, output: str, pubkeys: str) -> None:
     """Validate an apt repository at url"""
     if recursive:
@@ -94,7 +84,16 @@ def main() -> None:
 @recursive_option
 @click.argument("url", required=False)
 @click.option("--dists", required=False, help="Comma separated list of distributions.")
-@click.option("--apt-source", "-a", required=False, type=click.File("r"))
+@click.option(
+    "--apt-source",
+    "-a",
+    required=False,
+    type=click.File("r"),
+    help=(
+        "Supply apt sources.list file. When provided, all entries"
+        "will be parsed for repo urls and their respective dists."
+    )
+)
 @file_option
 @pubkey_option
 def apt(recursive: bool, url: str, dists: str, apt_source: str, output: str, pubkeys: str) -> None:

--- a/repoaudit/repoaudit/__init__.py
+++ b/repoaudit/repoaudit/__init__.py
@@ -34,6 +34,38 @@ pubkey_option = click.option(
     )
 )
 
+apt_sources_option = click.option(
+    "--apt-source",
+    "-a",
+    required=False,
+    help=(
+        "Supply apt sources.list file. When provided, all entries"
+        "will be parsed for repo urls and their respective dists."
+    )
+)
+
+def apt_helper(recursive: bool, url: str, dists: str, output: str, pubkeys: str) -> None:
+    """Helps apt function validate an apt repository at url"""
+    if recursive:
+        urls = get_repo_urls(url)
+    else:
+        urls = [url]
+
+    if dists:
+        dist_set = set(dists.split(","))
+    else:
+        dist_set = None
+
+    errors = RepoErrors()
+
+    with _gpg_cmdline(pubkeys) as gpg:
+        try:
+            for repo_url in urls:
+                check_apt_repo(repo_url, dist_set, gpg, errors)
+        except KeyboardInterrupt:
+            pass
+
+    output_result(errors, output)
 
 @contextmanager
 def _gpg_cmdline(pubkeys: str):
@@ -62,30 +94,21 @@ def main() -> None:
 @recursive_option
 @click.argument("url")
 @click.option("--dists", help="Comma separated list of distributions.")
+@apt_sources_option
 @file_option
 @pubkey_option
-def apt(recursive: bool, url: str, dists: str, output: str, pubkeys: str) -> None:
+def apt(recursive: bool, url: str, dists: str, apt_source: str, output: str, pubkeys: str) -> None:
     """Validate an apt repository at URL."""
-    if recursive:
-        urls = get_repo_urls(url)
+    if apt_source:
+        with open(apt_source, "r") as f:
+            lines = [line.strip() for line in f if line.startswith("deb")]
+            for line in lines:
+                fields = line.split(" ")
+                _url = fields[1]
+                _dists = ','.join(fields[slice(2, len(fields))])
+                apt_helper(recursive, _url, _dists, output, pubkeys)
     else:
-        urls = [url]
-
-    if dists:
-        dist_set = set(dists.split(","))
-    else:
-        dist_set = None
-
-    errors = RepoErrors()
-
-    with _gpg_cmdline(pubkeys) as gpg:
-        try:
-            for repo_url in urls:
-                check_apt_repo(repo_url, dist_set, gpg, errors)
-        except KeyboardInterrupt:
-            pass
-
-    output_result(errors, output)
+        apt_helper(recursive, url, dists, output, pubkeys)
 
 
 @main.command()

--- a/repoaudit/repoaudit/__init__.py
+++ b/repoaudit/repoaudit/__init__.py
@@ -34,6 +34,7 @@ pubkey_option = click.option(
     )
 )
 
+
 def _validate_apt_url(recursive: bool, url: str, dists: str, output: str, pubkeys: str) -> None:
     """Validate an apt repository at url"""
     if recursive:
@@ -56,6 +57,7 @@ def _validate_apt_url(recursive: bool, url: str, dists: str, output: str, pubkey
             pass
 
     output_result(errors, output)
+
 
 @contextmanager
 def _gpg_cmdline(pubkeys: str):

--- a/repoaudit/repoaudit/__init__.py
+++ b/repoaudit/repoaudit/__init__.py
@@ -94,16 +94,7 @@ def main() -> None:
 @recursive_option
 @click.argument("url", required=False)
 @click.option("--dists", required=False, help="Comma separated list of distributions.")
-@click.option(
-    "--apt-source",
-    "-a",
-    required=False,
-    type=click.File("r"),
-    help=(
-        "Supply apt sources.list file. When provided, all entries"
-        "will be parsed for repo urls and their respective dists."
-    )
-)
+@click.option("--apt-source", "-a", required=False, type=click.File("r"))
 @file_option
 @pubkey_option
 def apt(recursive: bool, url: str, dists: str, apt_source: str, output: str, pubkeys: str) -> None:
@@ -121,7 +112,7 @@ def apt(recursive: bool, url: str, dists: str, apt_source: str, output: str, pub
                 else:
                     raise Exception("No URL found")
                 url = fields[index]
-                dists = ','.join(fields[(index + 1):])
+                dists = fields[(index + 1)]
                 _validate_apt_url(recursive, url, dists, output, pubkeys)
         except IOError:
             print("Error: Unable to open file")


### PR DESCRIPTION
Summary: --apt-source, if provided, will parse out all entries in the sources.list file and run validation checks for each url and its respective distributions.

The original core function of apt has been extracted into a separate helper function, which can be called multiple times if necessary. Previous features are still usable, but have been made optional should the user decide to only use --apt-source.