### PR TITLE
Lock issues 30 days after closing

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,17 @@
+name: 'Lock Threads'
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  issues: write
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v5.0.1
+        with:
+          process-only: 'issues'
+          issue-lock-inactive-days: '30'


### PR DESCRIPTION
This adds a github action that will automatically lock issues 30 days after the issue is closed.