### PR TITLE
Update lock thread action timing

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -2,7 +2,7 @@ name: 'Lock Threads'
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '33 2 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
We're sometimes observing failures from this action and from the issue below it seems like using a different random time might solve this.

https://github.com/dessant/lock-threads/issues/48