### PR TITLE
Update docs referencing apt-mo and new signing key.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,31 @@ SQL packages from an IP address in one of the following Service Tags:
 * AzureCloud.westeurope
 * AzureCloud.westus2
 
+## Deprecated Support for Legacy Domain Names
+Historically,  packages.microsoft.com content was available on a second domain name: apt-mo.trafficmanager.net.
+This is a historical artifact from a time when packages.microsoft.com was not yet an official public offering.
+In May of 2025, we will be deprecating support for this domain name.
+Requests sent to this domain will be redirected to packages.microsoft.com to prevent impact.
+But customers using apt-mo are encouraged to update their repo references to prevent any future issues.
+This change will bring performance improvements, including better cache efficiency and faster cache purging operations.
+
 ## Signature Verification
 In general in rpm-based distributions it is common to sign the individual rpms but not the repository metadata, and in deb-based distributions it is common to sign the repository metadata but not the individual debs.
 Microsoft signs **both** the individual packages and the repository metadata for both types of distributions.
 The public keys used for verifying Microsoft signatures can be found at [/keys/](https://packages.microsoft.com/keys/).
+
+> [!IMPORTANT]
+> Starting in the May of 2025, packages.microsoft.com will be introducing a new signing key for some repositories.
+> As [users in the RHEL/Fedora community may be aware](https://github.com/microsoft/linux-package-repositories/issues/47),
+> the existing key (BE1229CF) includes SHA1 signatures.
+> These were commonplace when that key was created, but support for SHA1 (and keys that use it) has been deprecated in recent Linux releases.
+> The introduction of this new signing key represents our effort to keep pace with evolving security standards,
+> and ensure users of these new Linux releases can continue to be supported by packages.microsoft.com.
+>
+> Note that this change in policy does not indicate a lack of trust in the existing key.
+> It remains secure and trustworthy, and will continue to be used for existing repos.
+> The packages.microsoft.com team will continue to support our customers with the highest level of security and quality.
+> If any issues arise, do not hesitate to [file an issue](https://github.com/microsoft/linux-package-repositories/).
 
 ### Enabling Repository Metadata Signature Checking on RPM-Based Systems
 Set `repo_gpgcheck=1` in your repo file.


### PR DESCRIPTION
Update our public facing docs to reference the deprecation of apt-mo and the new signing key.