### PR TITLE
Fix zizmor install failure due to yanked indicatif dependency

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@fb51252c7ba57d633bc668f941da052e410add48 # v1
       - name: Get zizmor
-        run: cargo install zizmor
+        run: cargo install --locked zizmor
       - name: Run zizmor
         run: zizmor --format sarif . > results.sarif
       - name: Upload SARIF file


### PR DESCRIPTION
# Fix zizmor installation failure due to yanked indicatif dependency

## Issue Description
The GitHub Actions workflow for zizmor security analysis was failing during the `cargo install zizmor` step with the following error:

```
error: failed to compile `zizmor v1.11.0`, intermediate artifacts can be found at `/tmp/cargo-installqxsgmK`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.

Caused by:
  failed to select a version for the requirement `indicatif = "^0.17.12"`
    version 0.17.12 is yanked
  location searched: crates.io index
  required by package `zizmor v1.11.0`
```

## Root Cause
This issue occurs because:
1. **zizmor v1.11.0** (released June 30, 2025) depends on `indicatif = "^0.17.12"`
2. **Version 0.17.12 of `indicatif` was subsequently yanked** from crates.io
3. **Cargo's dependency resolution fails** when trying to find a compatible version in the `0.17.x` range

## Previous Reports
This **exact same issue** has been reported multiple times to the zizmor project:
- [Issue #1026](https://github.com/zizmorcore/zizmor/issues/1026) - First report (~28 days ago, July 2025)
- [Issue #1062](https://github.com/zizmorcore/zizmor/issues/1062) - Recent duplicate (5 days ago, August 2025)

## Official Recommendation
The zizmor maintainers **officially recommend** using the `--locked` flag for installation to avoid dependency resolution issues. This is documented in their installation guide at https://docs.zizmor.sh/installation/#cratesio.

A fix has been committed to the zizmor repository (commit `acf0b32d5966074f1305922724df17226e5c4c5c`) but has not yet been released.

## Solution Applied
Updated the zizmor installation command in `.github/workflows/zizmor.yml`:

```diff
- run: cargo install zizmor
+ run: cargo install --locked zizmor
```

The `--locked` flag ensures that Cargo uses the exact dependency versions from `Cargo.lock` that were tested by the zizmor developers, bypassing the problematic dependency resolution.
