### PR TITLE
Add dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,8 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    cooldown:
+      default-days: 7
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"


### PR DESCRIPTION
Add a dependabot cooldown to address zizmore security warning.

More info: https://github.com/zizmorcore/zizmor/pull/1223